### PR TITLE
Update component vertical's menu items to an IA option

### DIFF
--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -100,22 +100,37 @@ sections:
         slug: tables
         items:
           - label: Default tables
+            slug: default-tables
           - label: Sortable tables
+            slug: sortable-tables
           - label: Responsive tables
+            slug: responsive-tables
           - label: Snippet lists
+            slug: snippet-lists
       - label: Text
         slug: text
         items:
           - label: Dates
+            slug: dates
           - label: Definition lists
+            slug: definition-lists
           - label: Headers
+            slug: headers
           - label: Heading hierarchy
+            slug: heading-hierarchy
           - label: Helper text
+            slug: helper-text
           - label: Labels
+            slug: labels
           - label: Legends
+            slug: legends
           - label: Lists
+            slug: lists
           - label: Links
+            slug: links
           - label: Paragraphs
+            slug: paragraphs
           - label: Quotes
+            slug: quotes
   - label: Templates
     slug: templates

--- a/docs/_data/navigation.yml
+++ b/docs/_data/navigation.yml
@@ -13,15 +13,55 @@ sections:
             slug: modals
           - label: Notifications
             slug: notifications
+      - label: Content layouts
+        slug: content-layouts
+        items:
+          - label: Contact information
+            slug: contact-information
+          - label: Expandables
+            slug: expandables
+          - label: Featured content modules
+            slug: featured-content-modules
+          - label: Full width text
+            slug: full-width-text
+          - label: Heroes
+            slug: heroes
+          - label: Info unit groups
+            slug: info-unit-groups
+          - label: Introductions
+            slug: introductions
+          - label: Sidebars/prefooters
+            slug: sidebars-prefooters
+          - label: Wells
+            slug: wells
+      - label: Core utilities
+        slug: core-utilities
+        items:
+          - label: Atomic components
+            slug: atomic-components
+          - label: Blocks
+            slug: blocks
+          - label: Dividers
+            slug: dividers
+          - label: Grid
+            slug: grid
+          - label: Images
+            slug: images
+          - label: Media queries
+            slug: media-queries
+          - label: Utilities
+            slug: utilities
       - label: Data visualization
         slug: data-visualization
         items:
-          - label: Bar chart
-            slug: bar-chart
-          - label: Line chart
-            slug: line-chart
-          - label: Pie chart
-            slug: pie-chart
+          - label: Bar charts
+            slug: bar-charts
+          - label: Line charts
+            slug: line-charts
+          - label: Maps
+            slug: maps
+          - label: Pie charts
+            slug: pie-charts
       - label: Forms
         slug: forms
         items:
@@ -31,24 +71,51 @@ sections:
             slug: checkboxes
           - label: Dropdowns
             slug: dropdowns
-          - label: E-mail signup module
-            slug: e-mail-signup-module
+          - label: E-mail signup forms
+            slug: e-mail-signup-forms
           - label: Feedback forms
             slug: feedback-forms
           - label: Fieldsets
             slug: fieldsets
-          - label: Multi-select
-            slug: multi-select
+          - label: Multi-selects
+            slug: multi-selects
           - label: Radio buttons
             slug: radio-buttons
           - label: Range sliders
             slug: range-sliders
           - label: Text inputs
             slug: text-inputs
-      - label: Layout
-        slug: layout
+      - label: Navigation
+        slug: navigation
         items:
-          - label: xxxxxxxxxx
-            slug: xxxxxxxxxx
+          - label: Filterable list control panels
+            slug: filterable-list-control-panels
+          - label: Left hand navigation
+            slug: left-hand-navigation
+          - label: Megamenu
+            slug: megamenu
+          - label: Pagination
+            slug: pagination
+      - label: Tables
+        slug: tables
+        items:
+          - label: Default tables
+          - label: Sortable tables
+          - label: Responsive tables
+          - label: Snippet lists
+      - label: Text
+        slug: text
+        items:
+          - label: Dates
+          - label: Definition lists
+          - label: Headers
+          - label: Heading hierarchy
+          - label: Helper text
+          - label: Labels
+          - label: Legends
+          - label: Lists
+          - label: Links
+          - label: Paragraphs
+          - label: Quotes
   - label: Templates
     slug: templates


### PR DESCRIPTION
## Changes
- Updates the navigation with our most recent created IA for the component vertical.
- Tries to be consistent in labeling each component as a plural. (Exceptions: "Contact information", "Full width text", "Grid", "Left hand navigation", "Megamenu", "Pagination", "Heading hierarchy", and "Helper text")

## Thoughts
- Without collapsible subgroups, this vertical seems super long to try and parse/find/search at first view. We might be forcing people to rely on Ctrl-F while they learn the new organizational structures. (Something to watch for in testing, probably.)
- for @designlanguage, some possible things I only saw after getting this up for review:
  - I think that maybe "Megamenu" should be under the "Templates" vertical, instead of "Components > Navigation"? It feels much more like a template element to me that is decided on a site-wide basis than a multi-use building block for use within a single page.
  - And, maybe "Left hand navigation" is moved under "Layouts" (similar to sidebars or prefooters)?

## Screenshots
![Screen Shot 2019-06-21 at 8 48 46 AM](https://user-images.githubusercontent.com/1183435/59923516-9c51de80-9401-11e9-9603-f73ca84e1e51.png)
![Screen Shot 2019-06-21 at 8 49 42 AM](https://user-images.githubusercontent.com/1183435/59923521-9fe56580-9401-11e9-9654-de685a28012e.png)
![Screen Shot 2019-06-21 at 8 50 03 AM](https://user-images.githubusercontent.com/1183435/59923530-a378ec80-9401-11e9-95c8-7461b7a5db04.png)
