### PR TITLE
Add anchor link icons next to h3-level headings

### DIFF
--- a/docs/_includes/accessibility.html
+++ b/docs/_includes/accessibility.html
@@ -1,7 +1,7 @@
 {% if page.accessibility %}
-    <h3>Accessibility</h3>
+    <h3 id="accessibility">Accessibility</h3>
 
-    <section id="accessibility">
+    <section>
         <p>
             {{ page.accessibility | markdownify }}
         </p>

--- a/docs/_includes/component/help-us.html
+++ b/docs/_includes/component/help-us.html
@@ -1,8 +1,8 @@
 {% if page.help_us %}
 <div class="content-l_col content-l_col-1-2">
     <div>
-        <section id="help-us">
-            <h3>Help us make improvements</h3>
+        <section>
+            <h3 id="help-us">Help us make improvements</h3>
             {{ page.help_us | markdownify }}
         </section>
     </div>

--- a/docs/_includes/component/related-items.html
+++ b/docs/_includes/component/related-items.html
@@ -1,8 +1,8 @@
 {% if page.related_items %}
 <div class="content-l_col content-l_col-1-2">
     <div>
-        <section id="related-items">
-            <h3>Related Items</h3>
+        <section>
+            <h3 id="related-items">Related Items</h3>
             {{ page.related_items | markdownify }}
         </section>
     </div>

--- a/docs/_includes/intro.html
+++ b/docs/_includes/intro.html
@@ -19,6 +19,3 @@
     </li>
 </ul>
 
-<h3>Variations</h3>
-
-<section id="variations">

--- a/docs/_includes/research.html
+++ b/docs/_includes/research.html
@@ -1,7 +1,7 @@
 {% if page.research %}
-    <h3>Research</h3>
+    <h3 id="research">Research</h3>
 
-    <section id="research">
+    <section>
         <p>
             {{ page.research | markdownify }}
         </p>

--- a/docs/_includes/usage.html
+++ b/docs/_includes/usage.html
@@ -1,7 +1,7 @@
 {% if page.usage %}
-<h3>Usage</h3>
+<h3 id="usage">Usage</h3>
 
-    <section id="usage">
+    <section>
         <p>
             {{ page.usage | markdownify }}
         </p>

--- a/docs/_layouts/component.html
+++ b/docs/_layouts/component.html
@@ -51,60 +51,65 @@ layout: default
 
         {% include intro.html %}
 
-        {% for variation in page.variations %}
-        <div class="u-mt15">
-            <!-- Name -->
-            {% capture name %}{{ variation.variation_name }}{% endcapture %}
-            {% include variation/name.html %}
 
-            <!-- Description -->
-            {% capture description %}{{ variation.variation_description | markdownify }}{% endcapture %}
-            {% include variation/description.html %}
+        <h3 id="variations">Variations</h3>
 
-            <!-- Live code example -->
-            {% capture code_snippet %}{{ variation.variation_code_snippet }}{% endcapture %}
-            {% capture code_snippet_raw %}{% endcapture %}
-            {% include variation/code-snippet.html %}
+        <section>
+            {% for variation in page.variations %}
+            <div class="u-mt15">
+                <!-- Name -->
+                {% capture name %}{{ variation.variation_name }}{% endcapture %}
+                {% include variation/name.html %}
 
-            <div class="govuk-tabs u-mt30" data-module="tabs"  data-toggle-code>
-                <h2 class="govuk-tabs__title">
-                Contents
-                </h2>
+                <!-- Description -->
+                {% capture description %}{{ variation.variation_description | markdownify }}{% endcapture %}
+                {% include variation/description.html %}
 
-                <ul class="govuk-tabs__list">
-                    <li class="govuk-tabs__list-item">
-                        <a class="govuk-tabs__tab govuk-tabs__tab--selected" href="#html-code-snippet-{{ forloop.index }}">
-                        HTML                        </a>
-                    </li>
-                    <li class="govuk-tabs__list-item">
-                        <a class="govuk-tabs__tab" href="#jinja-code-snippet-{{ forloop.index }}">
-                        Jinja
-                        </a>
-                    </li>
-                </ul>
-                
-                <!-- HTML snippet -->
-                <section class="govuk-tabs__panel" id="html-code-snippet-{{ forloop.index }}">
-                    {% capture code_snippet %}{% endcapture %}
-                    {% capture code_snippet_raw %}{{ variation.variation_code_snippet | xml_escape }}{% endcapture %}
-                    {% include variation/code-snippet.html %}
-                </section>            
+                <!-- Live code example -->
+                {% capture code_snippet %}{{ variation.variation_code_snippet }}{% endcapture %}
+                {% capture code_snippet_raw %}{% endcapture %}
+                {% include variation/code-snippet.html %}
 
-                <!-- Jinja snippet -->
-                <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="jinja-code-snippet-{{ forloop.index }}">
-                    {% capture jinja_code_snippet %}{{ variation.variation_jinja_code_snippet | markdownify }}{% endcapture %}
-                    {% include variation/jinja-code-snippet.html %}
-                </section>
+                <div class="govuk-tabs u-mt30" data-module="tabs"  data-toggle-code>
+                    <h2 class="govuk-tabs__title">
+                    Contents
+                    </h2>
 
-            </div><!-- .govuk-tabs -->
+                    <ul class="govuk-tabs__list">
+                        <li class="govuk-tabs__list-item">
+                            <a class="govuk-tabs__tab govuk-tabs__tab--selected" href="#html-code-snippet-{{ forloop.index }}">
+                            HTML                        </a>
+                        </li>
+                        <li class="govuk-tabs__list-item">
+                            <a class="govuk-tabs__tab" href="#jinja-code-snippet-{{ forloop.index }}">
+                            Jinja
+                            </a>
+                        </li>
+                    </ul>
+                    
+                    <!-- HTML snippet -->
+                    <section class="govuk-tabs__panel" id="html-code-snippet-{{ forloop.index }}">
+                        {% capture code_snippet %}{% endcapture %}
+                        {% capture code_snippet_raw %}{{ variation.variation_code_snippet | xml_escape }}{% endcapture %}
+                        {% include variation/code-snippet.html %}
+                    </section>            
 
-            <!-- Specifications -->
-            {% if variation.variation_specs %}
-            {% capture specs %}{{ variation.variation_specs | markdownify }}{% endcapture %}
-            {% include variation/specs.html %}
-            {% endif %}
-        </div>
-        {% endfor %}
+                    <!-- Jinja snippet -->
+                    <section class="govuk-tabs__panel govuk-tabs__panel--hidden" id="jinja-code-snippet-{{ forloop.index }}">
+                        {% capture jinja_code_snippet %}{{ variation.variation_jinja_code_snippet | markdownify }}{% endcapture %}
+                        {% include variation/jinja-code-snippet.html %}
+                    </section>
+
+                </div><!-- .govuk-tabs -->
+
+                <!-- Specifications -->
+                {% if variation.variation_specs %}
+                {% capture specs %}{{ variation.variation_specs | markdownify }}{% endcapture %}
+                {% include variation/specs.html %}
+                {% endif %}
+            </div>
+            {% endfor %}
+        </section>
 
         {% include usage.html %}
 
@@ -117,7 +122,6 @@ layout: default
 
             {% include component/help-us.html %}
         </div><!-- .content-l -->
-
-    </section>
+    </section><!-- .content_main -->
   </div>
 </main>

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -61,7 +61,6 @@ function addPermalinks( headings ) {
   permalinks.forEach(
     permalink => permalink.addEventListener( 'click', ev => {
       const href = ev.currentTarget.href;
-      // console.log( href );
       copyAnchorLink( ev.currentTarget );
     } )
   );
@@ -70,20 +69,15 @@ function addPermalinks( headings ) {
 
 /**
  * Get href value and copy to clipboard
+ * @param {HTMLNode} linkEl - <a> anchor link element created in addPermalinks()
  */
 function copyAnchorLink( linkEl ) {
-  // do the copy
   const range = document.createRange();
   const linkText = linkEl.innerHTML;
   const linkURL = linkEl.href;
   // hackx to set the link text to equal the link url so we can select it and copy it to clipboard
-  // how can we get the whole url and note just the anchor bit....?
   linkEl.innerHTML = linkURL;
   range.selectNodeContents( linkEl );
-
-  console.log ( linkURL );
-  console.log ( linkEl );
-  console.log ( range );
 
   window.getSelection().addRange( range );
 

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -60,7 +60,6 @@ function addPermalinks( headings ) {
 
   permalinks.forEach(
     permalink => permalink.addEventListener( 'click', ev => {
-      ev.preventDefault();
       const href = ev.currentTarget.href;
       // console.log( href );
       copyAnchorLink( ev.currentTarget );

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -31,10 +31,10 @@ toggleButton.addEventListener( 'click', ev => {
 } );
 
 /**
- * create permalink elements for easy copy/paste of anchor links on specified heading elements 
+ * Create permalink elements for easy copy/paste of anchor links on specified heading elements.
+ * @param {HTMLNode} headings - List of target heading DOM elements, e.g. all <h3>'s
  */
 function addPermalinks( headings ) {
-
   const iconLink = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 929.5 1200" class="cf-icon-svg"><path d="M894.4 702.8L731.3 539.7c-46.9-46.8-122.8-46.8-169.7 0l-34.9 34.9-53.2-53.2 34.4-34.4c46.8-46.9 46.8-122.8 0-169.7L344.8 154.2c-46.9-46.8-122.8-46.8-169.7 0l-140 140c-46.8 46.9-46.8 122.8 0 169.7L198.2 627c46.9 46.8 122.8 46.8 169.7 0l34.9-34.9 53.2 53.2-34.4 34.4c-46.8 46.9-46.8 122.8 0 169.7l163.1 163.1c46.9 46.8 122.8 46.8 169.7 0l140-140c46.8-46.9 46.8-122.8 0-169.7zM297.2 556.2c-7.9 7.7-20.4 7.7-28.3 0l-163.1-163c-7.7-7.9-7.7-20.4 0-28.3l140-140c7.9-7.7 20.4-7.7 28.3 0l163 163.1c7.7 7.9 7.7 20.4 0 28.3l-34.4 34.4-55.5-55.5c-19.6-19.4-51.3-19.3-70.7.3-19.3 19.5-19.3 50.9 0 70.4l55.6 55.6-34.9 34.7zm526.5 245.6l-140 140c-7.9 7.7-20.4 7.7-28.3 0L492.3 778.7c-7.7-7.9-7.7-20.4 0-28.3l34.4-34.4 55.5 55.5c19.4 19.6 51.1 19.7 70.7.3s19.7-51.1.3-70.7l-.3-.3-55.5-55.5 34.9-34.9c7.9-7.7 20.4-7.7 28.3 0l163.1 163.1c7.7 7.9 7.7 20.4 0 28.3z"/></svg>';
 
   for ( let i = 0; i < headings.length; i++ ) {
@@ -44,6 +44,7 @@ function addPermalinks( headings ) {
       // create href with id of heading
       const link = document.createElement( 'a' );
       link.setAttribute( 'href', '#' + href );
+      link.setAttribute( 'data-anchor-link', '' );
       link.innerHTML = ' ' + iconLink + ' <small class="u-visually-hidden">Copy link to #' + href + ' section of this page</small>';
       // Title attribute is only useful as a hint to sighted users, screen readers need the actual link text above.
       link.setAttribute( 'title', 'Copy link to #' + href + ' section of this page' );
@@ -52,9 +53,27 @@ function addPermalinks( headings ) {
     }
 
   }
+  /**
+   * Add event listener to copy on click the anchor link href value for permalink icons next to headings.
+   */
+  const permalinks = document.querySelectorAll( '[data-anchor-link]' );
 
-  // @todo: copy href to clipboard on click
+  permalinks.forEach(
+    permalink => permalink.addEventListener( 'click', ev => {
+      ev.preventDefault();
+      console.log( ev.currentTarget.href );
+      copyAnchorLink( );
+    } )
+  );
 
+}
+
+/**
+ * Get href value and copy to clipboard
+ */
+function copyAnchorLink( ) {
+  // do the copy
+  console.log( 'do the copy' );
 }
 
 const h3Els = document.querySelectorAll( '.content_main h3' );

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -1,13 +1,13 @@
 import { Tabs } from 'govuk-frontend';
 
-const $main = document.querySelector( 'main.content' );
-const $tabs = document.querySelectorAll( '[data-module="tabs"]' );
+const main = document.querySelector( 'main.content' );
+const tabs = document.querySelectorAll( '[data-module="tabs"]' );
 
-if ( $tabs ) {
-  $main.classList.add( 'js-enabled' );
-  for ( let i = 0; i < $tabs.length; i++ ) {
-    const $tab = $tabs[i];
-    new Tabs( $tab ).init( );
+if ( tabs ) {
+  main.classList.add( 'js-enabled' );
+  for ( let i = 0; i < tabs.length; i++ ) {
+    const tab = tabs[i];
+    new Tabs( tab ).init( );
   }
 }
 

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -61,8 +61,9 @@ function addPermalinks( headings ) {
   permalinks.forEach(
     permalink => permalink.addEventListener( 'click', ev => {
       ev.preventDefault();
-      console.log( ev.currentTarget.href );
-      copyAnchorLink( );
+      const href = ev.currentTarget.href;
+      // console.log( href );
+      copyAnchorLink( ev.currentTarget );
     } )
   );
 
@@ -71,9 +72,36 @@ function addPermalinks( headings ) {
 /**
  * Get href value and copy to clipboard
  */
-function copyAnchorLink( ) {
+function copyAnchorLink( linkEl ) {
   // do the copy
-  console.log( 'do the copy' );
+  const range = document.createRange();
+  const linkText = linkEl.innerHTML;
+  const linkURL = linkEl.href;
+  // hackx to set the link text to equal the link url so we can select it and copy it to clipboard
+  // how can we get the whole url and note just the anchor bit....?
+  linkEl.innerHTML = linkURL;
+  range.selectNodeContents( linkEl );
+
+  console.log ( linkURL );
+  console.log ( linkEl );
+  console.log ( range );
+
+  window.getSelection().addRange( range );
+
+  try {
+    // Now that we've selected the anchor text, execute the copy command
+    var successful = document.execCommand('copy');
+    var msg = successful ? 'successful' : 'unsuccessful';
+    console.log('Copy email command was ' + msg);
+  } catch(err) {
+    console.log('Oops, unable to copy');
+  }
+
+  // Remove the selections - NOTE: Should use
+  // removeRange(range) when it is supported
+  window.getSelection().removeAllRanges();
+  linkEl.innerHTML = linkText;
+
 }
 
 const h3Els = document.querySelectorAll( '.content_main h3' );

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -29,3 +29,34 @@ toggleButton.addEventListener( 'click', ev => {
     toggleButton.setAttribute( 'data-code-hidden', 'true' );
   }
 } );
+
+/**
+ * create permalink elements for easy copy/paste of anchor links at every h3 heading
+ * @todo: for h4 headings too?
+ */
+function addPermalinks( ) {
+  const headings = document.querySelectorAll( '.content_main h3' );
+
+  for ( let i = 0; i < headings.length; i++ ) {
+    const heading = headings[i];
+    const href = heading.getAttribute( 'id' );
+    if ( href ) {
+      // create href with id of heading
+      const link = document.createElement( 'a' );
+      link.setAttribute( 'href', '#' + href );
+      
+      // @todo: use icon-copy.svg
+      link.innerHTML = ' <small>Copy link to #' + href + ' section of this page</small>';
+
+
+      // append to heading
+      heading.appendChild( link );
+    }
+
+  }
+
+  // @todo: copy href to clipboard on click
+
+}
+
+addPermalinks( );

--- a/docs/assets/js/main.js
+++ b/docs/assets/js/main.js
@@ -31,11 +31,11 @@ toggleButton.addEventListener( 'click', ev => {
 } );
 
 /**
- * create permalink elements for easy copy/paste of anchor links at every h3 heading
- * @todo: for h4 headings too?
+ * create permalink elements for easy copy/paste of anchor links on specified heading elements 
  */
-function addPermalinks( ) {
-  const headings = document.querySelectorAll( '.content_main h3' );
+function addPermalinks( headings ) {
+
+  const iconLink = '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 929.5 1200" class="cf-icon-svg"><path d="M894.4 702.8L731.3 539.7c-46.9-46.8-122.8-46.8-169.7 0l-34.9 34.9-53.2-53.2 34.4-34.4c46.8-46.9 46.8-122.8 0-169.7L344.8 154.2c-46.9-46.8-122.8-46.8-169.7 0l-140 140c-46.8 46.9-46.8 122.8 0 169.7L198.2 627c46.9 46.8 122.8 46.8 169.7 0l34.9-34.9 53.2 53.2-34.4 34.4c-46.8 46.9-46.8 122.8 0 169.7l163.1 163.1c46.9 46.8 122.8 46.8 169.7 0l140-140c46.8-46.9 46.8-122.8 0-169.7zM297.2 556.2c-7.9 7.7-20.4 7.7-28.3 0l-163.1-163c-7.7-7.9-7.7-20.4 0-28.3l140-140c7.9-7.7 20.4-7.7 28.3 0l163 163.1c7.7 7.9 7.7 20.4 0 28.3l-34.4 34.4-55.5-55.5c-19.6-19.4-51.3-19.3-70.7.3-19.3 19.5-19.3 50.9 0 70.4l55.6 55.6-34.9 34.7zm526.5 245.6l-140 140c-7.9 7.7-20.4 7.7-28.3 0L492.3 778.7c-7.7-7.9-7.7-20.4 0-28.3l34.4-34.4 55.5 55.5c19.4 19.6 51.1 19.7 70.7.3s19.7-51.1.3-70.7l-.3-.3-55.5-55.5 34.9-34.9c7.9-7.7 20.4-7.7 28.3 0l163.1 163.1c7.7 7.9 7.7 20.4 0 28.3z"/></svg>';
 
   for ( let i = 0; i < headings.length; i++ ) {
     const heading = headings[i];
@@ -44,11 +44,9 @@ function addPermalinks( ) {
       // create href with id of heading
       const link = document.createElement( 'a' );
       link.setAttribute( 'href', '#' + href );
-      
-      // @todo: use icon-copy.svg
-      link.innerHTML = ' <small>Copy link to #' + href + ' section of this page</small>';
-
-
+      link.innerHTML = ' ' + iconLink + ' <small class="u-visually-hidden">Copy link to #' + href + ' section of this page</small>';
+      // Title attribute is only useful as a hint to sighted users, screen readers need the actual link text above.
+      link.setAttribute( 'title', 'Copy link to #' + href + ' section of this page' );
       // append to heading
       heading.appendChild( link );
     }
@@ -59,4 +57,5 @@ function addPermalinks( ) {
 
 }
 
-addPermalinks( );
+const h3Els = document.querySelectorAll( '.content_main h3' );
+addPermalinks( h3Els );


### PR DESCRIPTION
adds anchor links to all h3-level headings

functionality is based on a common pattern in technical documentation, where there is an icon with the anchor link for the section next to headings on a page, so you can easily link to specific sub-sections of content on long pages. for some implementations of this pattern, you can click on the link and the anchor URL will copy to your clipboard. for browsers that don't support the copy JS, the link changes in the URL so that is copiable with the included anchor.

examples of this pattern elsewhere:

doesn't copy link:
- https://docs.travis-ci.com/user/languages/javascript-with-nodejs/#specifying-nodejs-versions
- https://github.com/cfpb/cfgov-refresh/blob/master/README.md#documentation
- https://jekyllrb.com/docs/themes/#overriding-theme-defaults
- https://cfpb.github.io/cfgov-refresh/#additional-dependencies
- https://github.com/cfpb/cfgov-refresh/blob/master/README.md#quickstart


## Additions

- JS that adds an icon with the anchor link for each h3-heading on component pages (e.g. Usage, Accessibility, Variations, Research)
- JS that copies the link to your clipboard when you click on the anchor link icon
- the link text is accessible (it's visually hidden and descriptive, it says "Copy link to #usage section of this page." the only problem with this is that the link text can be repetitive if you are navigating past multiple links on the page, for instance:
  - Copy link to #usage section of this page
  - Copy link to #research section of this page 
  - etc
 so it would be nice to think of a less repetitive way to be explicit about the link's functionality OR to make the unique part of the link (the anchor) the first or second word
- the title attribute is used with the same text, so that there is an indication of what the link does when you hover over it. title attributes are not read by screen readers so this will not cause duplicate text issues.

- 

## Removals

-

## Changes

- I moved IDs for the anchor link sections (usage, research etc) to the h3 instead of the containers below so that when you click on those horizontal links at the top of the page and the browser jumps you to the anchor, the heading is visible, and also so the JS can grab the anchor id from the heading and add the link next to it

## Testing

1. go to https://deploy-preview-40--test-design-system.netlify.com/design-system/components/buttons
1. click on the icons next to the h3 headings
1. open a new window and paste the URL in your clipboard into the address bar.
1. you should be taken to the section that you clicked the icon at
 
## Screenshots


## Notes

- we can change the icon, [maybe to a copy icon](https://cfpb.github.io/capital-framework/components/cf-icons/), to make it obvious-er what the link does
- 
![Screen Shot 2019-07-09 at 10 27 07 AM](https://user-images.githubusercontent.com/702526/60896325-25577b00-a234-11e9-8845-12540aafccbd.png)


## Todos

-

## Checklist

- [ ] PR has an informative and human-readable title
- [ ] Changes are limited to a single goal (no scope creep)
- [ ] Code can be automatically merged (no conflicts)
- [ ] Code follows the standards laid out in the [CFPB development guidelines](https://github.com/cfpb/development)
- [ ] Passes all existing automated tests
- [ ] Any _change_ in functionality is tested
- [ ] New functions are documented (with a description, list of inputs, and expected output)
- [ ] Placeholder code is flagged / future todos are captured in comments
- [ ] Visually tested in supported browsers and devices (see checklist below :point_down:)
- [ ] Project documentation has been updated
- [ ] Reviewers requested with the [Reviewers tool](https://help.github.com/articles/requesting-a-pull-request-review/) :arrow_right:

## Testing checklist

### Browsers

- [ ] Chrome on desktop
- [ ] Firefox
- [ ] Safari on macOS
- [ ] Edge
- [ ] Internet Explorer 9, 10, and 11
- [ ] Safari on iOS
- [ ] Chrome on Android

### Accessibility

- [ ] Keyboard friendly
- [ ] Screen reader friendly

### Other

- [ ] Is useable without CSS
- [ ] Is useable without JS
- [ ] Flexible from small to large screens
- [ ] No linting errors or warnings
- [ ] JavaScript tests are passing
